### PR TITLE
Adds an `every` call that can be chained in expectations for traversable

### DIFF
--- a/src/Every.php
+++ b/src/Every.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Expectations;
+
+use BadMethodCallException;
+
+/**
+ * @internal
+ *
+ * @mixin Expectation
+ */
+class Every
+{
+
+    /**
+     * @var Expectation
+     */
+    private $original;
+
+    /**
+     * Creates a new iterable expectation.
+     */
+    public function __construct(Expectation $original)
+    {
+        $this->original = $original;
+
+        if (!is_iterable($this->original->value)) {
+            throw new BadMethodCallException("The `every` call only support iterable types.");
+        }
+    }
+
+    public function and($value)
+    {
+        return new Expectation($value);
+    }
+
+    public function not()
+    {
+        return $this->original->not();
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        foreach ($this->original->value as $item) {
+            (new Expectation($item))->$name(...$arguments);
+        }
+
+        return $this;
+    }
+
+}

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -65,6 +65,14 @@ final class Expectation
     }
 
     /**
+     * Allows for expectations to be run over Iterables.
+     */
+    public function every()
+    {
+        return new Every($this);
+    }
+
+    /**
      * Asserts that two variables have the same type and
      * value. Used on objects, it asserts that two
      * variables reference the same object.

--- a/tests/Expect/every.php
+++ b/tests/Expect/every.php
@@ -1,0 +1,46 @@
+<?php
+
+test('an exception is thrown if the the type is not iterable', function() {
+    $this->expectException(BadMethodCallException::class);
+
+    expect('Foobar')
+        ->every()
+        ->toEqual('Foobar');
+});
+
+test('it maps over each iterable', function () {
+    expect([1, 1, 1])
+        ->every()
+        ->toEqual(1);
+});
+
+test('it accepts chained expectations', function() {
+    expect([1, 1, 1])
+        ->every()
+        ->toBeInt()
+        ->toEqual(1);
+});
+
+test('it works with the not operator', function() {
+    expect([1, 2, 3])
+        ->every()
+        ->not()->toEqual(4);
+});
+
+test('it works with the and operator', function() {
+    expect([1, 2, 3])
+        ->every()
+        ->not()->toEqual(4)
+        ->and([4, 5, 6])
+        ->every()
+        ->toBeLessThan(7)
+        ->toBeGreaterThan(3)
+        ->and('Hello World')
+        ->toBeString()
+        ->toEqual('Hello World');
+});
+
+test('it can be called as a higher order function', function () {
+    expect([1, 1, 1])
+        ->every->toEqual(1);
+});


### PR DESCRIPTION
Often, I find myself wanting to assert that everything in an array or Laravel Collection passes a given test.

For example, I might want to make sure that everything in a Collection is an instance of a certain class, or that no item in an array is greater than a certain value.

This PR adds the `every` method, which allows the user to perform assertions on individual items in iterable values.

## Usage

Imagine we want to make sure that every item in an array is less than 100. This PR allows for this with the `every` method:

```php
test('it works', function () {
    expect(range(1, 99))
        ->every->toBeLessThan(100);
});
```

It works with `not` and `and` methods:

```php
test('it works', function () {
    expect(range(1, 99))
        ->every->not->toBeString()
        ->and(['hello', 'world'])
        ->every->not->toBeInt();
});
```

If this is something that you see as valuable, let me know if there are any changes you'd like to see and I shall sort it 👍

Thanks for the insanely beautiful API that is the expectations plugin!