### PR TITLE
Fixes a bug with `not` when using `each`

### DIFF
--- a/src/Each.php
+++ b/src/Each.php
@@ -58,9 +58,7 @@ final class Each
     {
         foreach ($this->original->value as $item) {
             /* @phpstan-ignore-next-line */
-            $this->expectsOpposite
-                ? expect($item)->not()->$name(...$arguments)
-                : expect($item)->$name(...$arguments);
+            $this->expectsOpposite ? expect($item)->not()->$name(...$arguments) : expect($item)->$name(...$arguments);
         }
 
         $this->expectsOpposite = false;
@@ -73,6 +71,7 @@ final class Each
      */
     public function __get(string $name): Each
     {
+        /* @phpstan-ignore-next-line */
         return $this->$name();
     }
 }

--- a/src/Each.php
+++ b/src/Each.php
@@ -17,6 +17,11 @@ final class Each
     private $original;
 
     /**
+     * @var bool
+     */
+    private $expectsOpposite = false;
+
+    /**
      * Creates an expectation on each item of the traversable "value".
      */
     public function __construct(Expectation $original)
@@ -37,9 +42,11 @@ final class Each
     /**
      * Creates the opposite expectation for the value.
      */
-    public function not(): OppositeExpectation
+    public function not(): Each
     {
-        return $this->original->not();
+        $this->expectsOpposite = true;
+
+        return $this;
     }
 
     /**
@@ -51,8 +58,12 @@ final class Each
     {
         foreach ($this->original->value as $item) {
             /* @phpstan-ignore-next-line */
-            expect($item)->$name(...$arguments);
+            $this->expectsOpposite
+                ? expect($item)->not()->$name(...$arguments)
+                : expect($item)->$name(...$arguments);
         }
+
+        $this->expectsOpposite = false;
 
         return $this;
     }
@@ -62,11 +73,6 @@ final class Each
      */
     public function __get(string $name): Each
     {
-        foreach ($this->original->value as $item) {
-            /* @phpstan-ignore-next-line */
-            expect($item)->$name();
-        }
-
-        return $this;
+        return $this->$name();
     }
 }

--- a/tests/Expect/each.php
+++ b/tests/Expect/each.php
@@ -36,13 +36,29 @@ it('chains expectations on each item', function () {
     expect(static::getCount())->toBe(13);
 });
 
-test('oposite expectations on each item', function () {
+test('opposite expectations on each item', function () {
     expect([1, 2, 3])
         ->each()
         ->not()
         ->toEqual(4);
 
     expect(static::getCount())->toBe(3);
+
+    expect([1, 2, 3])
+        ->each()
+        ->not->toBeString;
+
+    expect(static::getCount())->toBe(7);
+});
+
+test('chained opposite and non-opposite expectations', function () {
+    expect([1, 2, 3])
+        ->each()
+        ->not()
+        ->toEqual(4)
+        ->toBeInt();
+
+    expect(static::getCount())->toBe(6);
 });
 
 it('can add expectations via "and"', function () {


### PR DESCRIPTION
As per your request to look into the `not` bug, here is the fix.

Basically, as it was, when `not` was called we were leaving the `each` loop system. This instead tracks the `not` internally and then appends it in the `foreach` loop as required. 