### PR TITLE
Adds a `sequence` method for traversable values

### DIFF
--- a/src/Each.php
+++ b/src/Each.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Expectations;
 
+use BadMethodCallException;
+
 /**
  * @internal
  *
@@ -27,6 +29,35 @@ final class Each
     public function __construct(Expectation $original)
     {
         $this->original = $original;
+    }
+
+    /**
+     * Allows you to specify a sequential set of
+     * expectations for each item in a
+     * traversable "value".
+     *
+     * @param callable ...$expectations
+     */
+    public function sequence(...$expectations): Each
+    {
+        if (!is_iterable($this->original->value)) {
+            throw new BadMethodCallException('Expectation value is not traversable.');
+        }
+
+        $expectationIndex = 0;
+
+        /* @phpstan-ignore-next-line */
+        while (count($expectations) < count($this->original->value)) {
+            $expectations[] = $expectations[$expectationIndex];
+            /* @phpstan-ignore-next-line */
+            $expectationIndex = $expectationIndex < count($this->original->value) - 1 ? $expectationIndex + 1 : 0;
+        }
+
+        foreach ($this->original->value as $index => $item) {
+            call_user_func($expectations[$index], expect($item));
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -91,16 +91,16 @@ final class Expectation
      *
      * @param callable ...$expectations
      */
-    public function sequence(...$expectations)
+    public function sequence(...$expectations): Expectation
     {
         if (!is_iterable($this->value)) {
             throw new BadMethodCallException('Expectation value is not traversable.');
         }
 
-        $index = 0;
+        $expectationIndex = 0;
         while (count($expectations) < count($this->value)) {
-            $expectations[] = $expectations[$index];
-            $index = $index < count($this->value) - 1 ? $index + 1 : 0;
+            $expectations[] = $expectations[$expectationIndex];
+            $expectationIndex = $expectationIndex < count($this->value) - 1 ? $expectationIndex + 1 : 0;
         }
 
         foreach ($this->value as $index => $item) {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -85,35 +85,6 @@ final class Expectation
     }
 
     /**
-     * Allows you to specify a sequential set of
-     * expectations for each item in a
-     * traversable "value".
-     *
-     * @param callable ...$expectations
-     */
-    public function sequence(...$expectations): Expectation
-    {
-        if (!is_iterable($this->value)) {
-            throw new BadMethodCallException('Expectation value is not traversable.');
-        }
-
-        $expectationIndex = 0;
-
-        /* @phpstan-ignore-next-line */
-        while (count($expectations) < count($this->value)) {
-            $expectations[]   = $expectations[$expectationIndex];
-            /* @phpstan-ignore-next-line */
-            $expectationIndex = $expectationIndex < count($this->value) - 1 ? $expectationIndex + 1 : 0;
-        }
-
-        foreach ($this->value as $index => $item) {
-            call_user_func($expectations[$index], expect($item));
-        }
-
-        return $this;
-    }
-
-    /**
      * Asserts that two variables have the same type and
      * value. Used on objects, it asserts that two
      * variables reference the same object.

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -98,8 +98,11 @@ final class Expectation
         }
 
         $expectationIndex = 0;
+
+        /* @phpstan-ignore-next-line */
         while (count($expectations) < count($this->value)) {
             $expectations[]   = $expectations[$expectationIndex];
+            /* @phpstan-ignore-next-line */
             $expectationIndex = $expectationIndex < count($this->value) - 1 ? $expectationIndex + 1 : 0;
         }
 

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -99,7 +99,7 @@ final class Expectation
 
         $expectationIndex = 0;
         while (count($expectations) < count($this->value)) {
-            $expectations[] = $expectations[$expectationIndex];
+            $expectations[]   = $expectations[$expectationIndex];
             $expectationIndex = $expectationIndex < count($this->value) - 1 ? $expectationIndex + 1 : 0;
         }
 

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -85,6 +85,32 @@ final class Expectation
     }
 
     /**
+     * Allows you to specify a sequential set of
+     * expectations for each item in a
+     * traversable "value".
+     *
+     * @param callable ...$expectations
+     */
+    public function sequence(...$expectations)
+    {
+        if (!is_iterable($this->value)) {
+            throw new BadMethodCallException('Expectation value is not traversable.');
+        }
+
+        $index = 0;
+        while (count($expectations) < count($this->value)) {
+            $expectations[] = $expectations[$index];
+            $index = $index < count($this->value) - 1 ? $index + 1 : 0;
+        }
+
+        foreach ($this->value as $index => $item) {
+            call_user_func($expectations[$index], expect($item));
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts that two variables have the same type and
      * value. Used on objects, it asserts that two
      * variables reference the same object.

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -1,11 +1,12 @@
 <?php
 
 test('an exception is thrown if the the type is not iterable', function () {
-    expect('Foobar')->sequence();
+    expect('Foobar')->each->sequence();
 })->throws(BadMethodCallException::class, 'Expectation value is not traversable.');
 
 test('allows for sequences of checks to be run on traversable data', function () {
     expect([1, 2, 3])
+        ->each
         ->sequence(
             function ($expectation) { $expectation->toBeInt()->toEqual(1); },
             function ($expectation) { $expectation->toBeInt()->toEqual(2); },
@@ -17,6 +18,7 @@ test('allows for sequences of checks to be run on traversable data', function ()
 
 test('loops back to the start if it runs out of sequence items', function () {
     expect([1, 2, 3, 1, 2, 3, 1, 2])
+        ->each
         ->sequence(
             function ($expectation) { $expectation->toBeInt()->toEqual(1); },
             function ($expectation) { $expectation->toBeInt()->toEqual(2); },
@@ -28,6 +30,7 @@ test('loops back to the start if it runs out of sequence items', function () {
 
 test('it works if the number of items in the traversable is smaller than the number of expectations', function () {
     expect([1, 2])
+        ->each
         ->sequence(
             function ($expectation) { $expectation->toBeInt()->toEqual(1); },
             function ($expectation) { $expectation->toBeInt()->toEqual(2); },

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -15,7 +15,7 @@ test('allows for sequences of checks to be run on traversable data', function ()
     expect(static::getCount())->toBe(6);
 });
 
-test('loops back to the start if it runs out of sequence items', function() {
+test('loops back to the start if it runs out of sequence items', function () {
     expect([1, 2, 3, 1, 2, 3, 1, 2])
         ->sequence(
             function($expectation) { $expectation->toBeInt()->toEqual(1); },
@@ -36,4 +36,3 @@ test('it works if the number of items in the traversable is smaller than the num
 
     expect(static::getCount())->toBe(4);
 });
-

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -1,0 +1,39 @@
+<?php
+
+test('an exception is thrown if the the type is not iterable', function () {
+    expect('Foobar')->sequence();
+})->throws(BadMethodCallException::class, 'Expectation value is not traversable.');
+
+test('allows for sequences of checks to be run on traversable data', function () {
+    expect([1, 2, 3])
+        ->sequence(
+            function($expectation) { $expectation->toBeInt()->toEqual(1); },
+            function($expectation) { $expectation->toBeInt()->toEqual(2); },
+            function($expectation) { $expectation->toBeInt()->toEqual(3); },
+        );
+
+    expect(static::getCount())->toBe(6);
+});
+
+test('loops back to the start if it runs out of sequence items', function() {
+    expect([1, 2, 3, 1, 2, 3, 1, 2])
+        ->sequence(
+            function($expectation) { $expectation->toBeInt()->toEqual(1); },
+            function($expectation) { $expectation->toBeInt()->toEqual(2); },
+            function($expectation) { $expectation->toBeInt()->toEqual(3); },
+        );
+
+    expect(static::getCount())->toBe(16);
+});
+
+test('it works if the number of items in the traversable is smaller than the number of expectations', function () {
+    expect([1, 2])
+        ->sequence(
+            function($expectation) { $expectation->toBeInt()->toEqual(1); },
+            function($expectation) { $expectation->toBeInt()->toEqual(2); },
+            function($expectation) { $expectation->toBeInt()->toEqual(3); },
+        );
+
+    expect(static::getCount())->toBe(4);
+});
+

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -7,9 +7,9 @@ test('an exception is thrown if the the type is not iterable', function () {
 test('allows for sequences of checks to be run on traversable data', function () {
     expect([1, 2, 3])
         ->sequence(
-            function($expectation) { $expectation->toBeInt()->toEqual(1); },
-            function($expectation) { $expectation->toBeInt()->toEqual(2); },
-            function($expectation) { $expectation->toBeInt()->toEqual(3); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(1); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(2); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(3); },
         );
 
     expect(static::getCount())->toBe(6);
@@ -18,9 +18,9 @@ test('allows for sequences of checks to be run on traversable data', function ()
 test('loops back to the start if it runs out of sequence items', function () {
     expect([1, 2, 3, 1, 2, 3, 1, 2])
         ->sequence(
-            function($expectation) { $expectation->toBeInt()->toEqual(1); },
-            function($expectation) { $expectation->toBeInt()->toEqual(2); },
-            function($expectation) { $expectation->toBeInt()->toEqual(3); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(1); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(2); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(3); },
         );
 
     expect(static::getCount())->toBe(16);
@@ -29,9 +29,9 @@ test('loops back to the start if it runs out of sequence items', function () {
 test('it works if the number of items in the traversable is smaller than the number of expectations', function () {
     expect([1, 2])
         ->sequence(
-            function($expectation) { $expectation->toBeInt()->toEqual(1); },
-            function($expectation) { $expectation->toBeInt()->toEqual(2); },
-            function($expectation) { $expectation->toBeInt()->toEqual(3); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(1); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(2); },
+            function ($expectation) { $expectation->toBeInt()->toEqual(3); },
         );
 
     expect(static::getCount())->toBe(4);


### PR DESCRIPTION
Me again!

Part two of my little ballet of code is the `sequence` method. Imagine that you have a traversable array or collection and you want to check that each item sequentially follows a set of assertions.

I often need this kind of functionality when I'm dealing with mocked responses, and I want to make sure that the values returned in a collection of objects match the mock.

Here's an example of the usage:

```php
/**
 * The mocked UserImporter class returns 3 user objects.
 * The first user is called Luke, the second Nuno and 
 * the third Taylor. We want to check they've 
 * actually been imported as expected.
 */
$users = resolve(UserImporter::class)->import(); 

expect($users->map->name)->sequence(
    fn($expect) => $expect->toEqual('Luke'),
    fn($expect) => $expect->toEqual('Nuno'),
    fn($expect) => $expect->toEqual('Taylor'),
);
```

If you like this and feel it warrants becoming part of the expectation API, there is a point of discussion, which is "should a BedMethodCall exception be thrown if the number of items in the traversable is less than the number of declared sequence items?"

Have a great weekend!