### PR TITLE
Wrap expect function in a function_exists

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -10,18 +10,20 @@ if (class_exists(Pest\Plugin::class)) {
     Pest\Plugin::uses(Expectations::class);
 }
 
-/**
- * Creates a new expectation.
- *
- * @param mixed $value the Value
- *
- * @return Expectation|Extendable
- */
-function expect($value = null)
-{
-    if (func_num_args() === 0) {
-        return new Extendable(Expectation::class);
-    }
+if (! function_exists('expect')) {
+    /**
+     * Creates a new expectation.
+     *
+     * @param mixed $value the Value
+     *
+     * @return Expectation|Extendable
+     */
+    function expect($value = null)
+    {
+        if (func_num_args() === 0) {
+            return new Extendable(Expectation::class);
+        }
 
-    return new Expectation($value);
+        return new Expectation($value);
+    }
 }


### PR DESCRIPTION
It's often a great practice to wrap function declaration in `function_exists`.

This will also resolve a crash in rector where they have a function named the same.