### PR TITLE
Sequences now work with associative arrays and objects

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -93,18 +93,19 @@ final class Expectation
             throw new BadMethodCallException('Expectation value is not iterable.');
         }
 
+        $value  = is_array($this->value) ? $this->value : iterator_to_array($this->value);
+        $keys   = array_keys($value);
+        $values = array_values($value);
+
         $index = 0;
 
-        /* @phpstan-ignore-next-line */
-        while (count($callbacks) < count($this->value)) {
+        while (count($callbacks) < count($values)) {
             $callbacks[] = $callbacks[$index];
-            /* @phpstan-ignore-next-line */
-            $index = $index < count($this->value) - 1 ? $index + 1 : 0;
+            $index       = $index < count($values) - 1 ? $index + 1 : 0;
         }
 
-        /* @phpstan-ignore-next-line */
-        foreach ($this->value as $index => $item) {
-            call_user_func($callbacks[$index], expect($item));
+        foreach ($values as $key => $item) {
+            call_user_func($callbacks[$key], expect($item), $keys[$key]);
         }
 
         return $this;

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -105,7 +105,7 @@ final class Expectation
         }
 
         foreach ($values as $key => $item) {
-            call_user_func($callbacks[$key], expect($item), $keys[$key]);
+            call_user_func($callbacks[$key], expect($item), expect($keys[$key]));
         }
 
         return $this;

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -36,3 +36,11 @@ test('it works if the number of items in the iterable is smaller than the number
 
     expect(static::getCount())->toBe(4);
 });
+
+test('it works with associative arrays', function () {
+    expect(['foo' => 'bar', 'baz' => 'boom'])
+        ->sequence(
+            function ($expectation, $key) { $expectation->toEqual('bar'); expect($key)->toEqual('foo'); },
+            function ($expectation, $key) { $expectation->toEqual('boom'); expect($key)->toEqual('baz'); },
+        );
+});

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -40,7 +40,7 @@ test('it works if the number of items in the iterable is smaller than the number
 test('it works with associative arrays', function () {
     expect(['foo' => 'bar', 'baz' => 'boom'])
         ->sequence(
-            function ($expectation, $key) { $expectation->toEqual('bar'); expect($key)->toEqual('foo'); },
-            function ($expectation, $key) { $expectation->toEqual('boom'); expect($key)->toEqual('baz'); },
+            function ($expectation, $key) { $expectation->toEqual('bar'); $key->toEqual('foo'); },
+            function ($expectation, $key) { $expectation->toEqual('boom'); $key->toEqual('baz'); },
         );
 });


### PR DESCRIPTION
Previously, attempting the `sequence` method on an associative array or Collection with strings as keys would throw an error. This PR adds support for this, allowing you to make sequence assertions as if the array were indexed normally.

```php
$example = ['foo' => 'bar', 'baz' => 'bang'];

expect($example)
    ->sequence(
        fn($item, $key) => $item->toEqual('bar'),
        fn($item, $key) => $key->toEqual('baz'),
    );
```