### PR TITLE
Adds HigherOrderExpectations

### DIFF
--- a/src/Concerns/Extendable.php
+++ b/src/Concerns/Extendable.php
@@ -44,7 +44,7 @@ trait Extendable
     public function __call(string $method, array $parameters)
     {
         if (!static::hasExtend($method)) {
-            return new HigherOrderExpectation($this, $method, true, ...$parameters);
+            return HigherOrderExpectation::forMethod($this, $method, ...$parameters);
         }
 
         /** @var Closure $extend */

--- a/src/Concerns/Extendable.php
+++ b/src/Concerns/Extendable.php
@@ -44,7 +44,7 @@ trait Extendable
     public function __call(string $method, array $parameters)
     {
         if (!static::hasExtend($method)) {
-            return HigherOrderExpectation::forMethod($this, $method, ...$parameters);
+            return new HigherOrderExpectation($this, $method, $parameters);
         }
 
         /** @var Closure $extend */

--- a/src/Concerns/Extendable.php
+++ b/src/Concerns/Extendable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Expectations\Concerns;
 
-use BadMethodCallException;
 use Closure;
+use Pest\Expectations\HigherOrderExpectation;
 
 /**
  * @internal
@@ -40,12 +40,11 @@ trait Extendable
      *
      * @return mixed
      *
-     * @throws BadMethodCallException
      */
     public function __call(string $method, array $parameters)
     {
         if (!static::hasExtend($method)) {
-            throw new BadMethodCallException(sprintf('Method %s::%s does not exist.', static::class, $method));
+            return new HigherOrderExpectation($this, $method, true, ...$parameters);
         }
 
         /** @var Closure $extend */

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -680,12 +680,17 @@ final class Expectation
     }
 
     /**
-     * Dynamically calls methods on the class without any arguments.
+     * Dynamically calls methods on the class without any arguments
+     * or creates a new higher order expectation.
      *
-     * @return Expectation
+     * @return Expectation|HigherOrderExpectation
      */
     public function __get(string $name)
     {
+        if (!method_exists($this, $name) && !static::hasExtend($name)) {
+            return new HigherOrderExpectation($this, $name);
+        }
+
         /* @phpstan-ignore-next-line */
         return $this->{$name}();
     }

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -688,7 +688,7 @@ final class Expectation
     public function __get(string $name)
     {
         if (!method_exists($this, $name) && !static::hasExtend($name)) {
-            return new HigherOrderExpectation($this, $name);
+            return HigherOrderExpectation::forProperty($this, $name);
         }
 
         /* @phpstan-ignore-next-line */

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -688,7 +688,7 @@ final class Expectation
     public function __get(string $name)
     {
         if (!method_exists($this, $name) && !static::hasExtend($name)) {
-            return HigherOrderExpectation::forProperty($this, $name);
+            return new HigherOrderExpectation($this, $name);
         }
 
         /* @phpstan-ignore-next-line */

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -21,7 +21,7 @@ final class HigherOrderExpectation
     private $original;
 
     /**
-     * @var Expectation|Each|OppositeExpectation
+     * @var Expectation|Each
      */
     private $expectation;
 

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Expectations;
+
+use Pest\Expectations\Concerns\Expectations;
+
+/**
+ * @internal
+ *
+ * @mixin Expectation
+ */
+final class HigherOrderExpectation
+{
+    use Expectations;
+
+    /**
+     * @var Expectation
+     */
+    private $original;
+
+    /**
+     * @var Expectation|Each|OppositeExpectation
+     */
+    private $expectation;
+
+    /**
+     * @var bool
+     */
+    private $opposite;
+
+    /**
+     * @var string
+     */
+    private $property;
+
+    /**
+     * Creates a new higher order expectation.
+     */
+    public function __construct(Expectation $original, string $property)
+    {
+        $this->original = $original;
+        $this->property = $property;
+        $this->expectation = $this->expect($this->getPropertyValue());
+    }
+
+    /**
+     * Retrieves the property value from the original expectation.
+     */
+    private function getPropertyValue()
+    {
+        if (is_array($this->original->value)) {
+            return $this->original->value[$this->property];
+        }
+
+        if (is_object($this->original->value)) {
+            return $this->original->value->{$this->property};
+        }
+    }
+
+    /**
+     * Creates the opposite expectation for the value.
+     */
+    public function not(): HigherOrderExpectation
+    {
+        $this->opposite = true;
+
+        return $this;
+    }
+
+    /**
+     * Dynamically calls methods on the class with the given arguments on each item.
+     *
+     * @param array<int|string, mixed> $arguments
+     */
+    public function __call(string $name, array $arguments): HigherOrderExpectation
+    {
+        $this->expectation = $this->opposite
+            ? $this->expectation->not()->{$name}(...$arguments)
+            : $this->expectation->{$name}(...$arguments);
+
+        $this->opposite = false;
+
+        return $this;
+    }
+
+    /**
+     * Accesses properties in the value or in the expectation.
+     */
+    public function __get(string $name): HigherOrderExpectation
+    {
+        if ($name == 'not') {
+            return $this->not();
+        }
+
+        if (!$this->originalExpectationHasMethod($name)) {
+            return new static($this->original, $name);
+        }
+
+        $this->expectation = $this->expectation->{$name};
+        return $this;
+    }
+
+    /**
+     * Determines if the original expectation has the given method name.
+     */
+    private function originalExpectationHasMethod($name): bool
+    {
+        return method_exists($this->original, $name) || $this->original::hasExtend($name);
+    }
+}

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -76,13 +76,7 @@ final class HigherOrderExpectation
      */
     public function __call(string $name, array $arguments): HigherOrderExpectation
     {
-        $this->expectation = $this->opposite
-            ? $this->expectation->not()->{$name}(...$arguments)
-            : $this->expectation->{$name}(...$arguments);
-
-        $this->opposite = false;
-
-        return $this;
+        return $this->performAssertion($name, ...$arguments);
     }
 
     /**
@@ -98,7 +92,20 @@ final class HigherOrderExpectation
             return new static($this->original, $name);
         }
 
-        $this->expectation = $this->expectation->{$name};
+        return $this->performAssertion($name);
+    }
+
+    /**
+     * Performs the given assertion with the current expectation.
+     */
+    private function performAssertion($name, ...$arguments)
+    {
+        $this->expectation = $this->opposite
+            ? $this->expectation->not()->{$name}(...$arguments)
+            : $this->expectation->{$name}(...$arguments);
+
+        $this->opposite = false;
+
         return $this;
     }
 

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -48,9 +48,17 @@ final class HigherOrderExpectation
     /**
      * Generates the initial state of the expectation.
      */
-    private function generateInitialExpectation($asMethod, ...$arguments)
+    private function generateInitialExpectation(bool $asMethod, ...$arguments)
     {
-        return $this->expect($asMethod ? $this->original->value->{$this->name}(...$arguments) : $this->getPropertyValue());
+        return $this->expect($asMethod ? $this->getMethodValue(...$arguments) : $this->getPropertyValue());
+    }
+
+    /**
+     * Retrieves the value of the method from the original expectation.
+     */
+    private function getMethodValue(...$arguments)
+    {
+        return $this->original->value->{$this->name}(...$arguments);
     }
 
     /**

--- a/tests/Expect/HigherOrder/higherOrder.php
+++ b/tests/Expect/HigherOrder/higherOrder.php
@@ -19,7 +19,24 @@ it('works with not', function () {
 it('works with each', function () {
     expect(['numbers' => [1,2,3,4], 'words' => ['hey', 'there']])
         ->numbers->toEqual([1,2,3,4])->each->toBeInt->toBeLessThan(5)
-        ->words->each(fn ($word) => $word->toBeString())->not->toBeInt();
+        ->words->each(function ($word) {
+            $word->toBeString()->not->toBeInt();
+        });
+});
+
+it('works inside of each', function () {
+    expect(['books' => [['title' => 'Foo', 'cost' => 20], ['title' => 'Bar', 'cost' => 30]]])
+        ->books->each(function ($book) {
+            $book->title->not->toBeNull->cost->toBeGreaterThan(19);
+        });
+});
+
+it('works with sequence', function () {
+    expect(['books' => [['title' => 'Foo', 'cost' => 20], ['title' => 'Bar', 'cost' => 30]]])
+        ->books->sequence(
+            function ($book) { $book->title->toEqual('Foo')->cost->toEqual(20); },
+            function ($book) { $book->title->toEqual('Bar')->cost->toEqual(30); },
+        );
 });
 
 it('can compose complex expectations', function () {
@@ -31,7 +48,11 @@ it('can compose complex expectations', function () {
 });
 
 it('works with objects', function () {
-    expect((object) ['foo' => 'bar', 'numbers' => [1,2,3,4]])
-        ->foo->toEqual('bar')->not->toEqual('world')
-        ->numbers->each->toBeInt->tobeLessThan(5);
+    expect((object) ['name' => 'foo', 'posts' => [['is_published' => true, 'title' => 'Foo'], ['is_published' => true, 'title' => 'Bar']]])
+        ->name->toEqual('foo')->not->toEqual('world')
+        ->posts->toHaveCount(2)->each(function ($post) { $post->is_published->toBeTrue(); })
+        ->posts->sequence(
+            function ($post) { $post->title->toEqual('Foo'); },
+            function ($post) { $post->title->toEqual('Bar'); },
+        );
 });

--- a/tests/Expect/HigherOrder/higherOrder.php
+++ b/tests/Expect/HigherOrder/higherOrder.php
@@ -13,7 +13,7 @@ it('can access multiple properties from the value', function () {
 it('works with not', function () {
     expect(['foo' => 'bar', 'hello' => 'world'])
         ->foo->not->toEqual('world')->toEqual('bar')
-        ->hello->toEqual('world')->not()->toEqual('bar');
+        ->hello->toEqual('world')->not()->toEqual('bar')->not->toBeNull;
 });
 
 it('works with each', function () {

--- a/tests/Expect/HigherOrder/higherOrder.php
+++ b/tests/Expect/HigherOrder/higherOrder.php
@@ -1,0 +1,37 @@
+<?php
+
+it('allows properties to be accessed from the value', function () {
+    expect(['foo' => 1])->foo->toBeInt()->toEqual(1);
+});
+
+it('can access multiple properties from the value', function () {
+    expect(['foo' => 'bar', 'hello' => 'world'])
+        ->foo->toBeString()->toEqual('bar')
+        ->hello->toBeString()->toEqual('world');
+});
+
+it('works with not', function () {
+    expect(['foo' => 'bar', 'hello' => 'world'])
+        ->foo->not->toEqual('world')->toEqual('bar')
+        ->hello->toEqual('world')->not()->toEqual('bar');
+});
+
+it('works with each', function () {
+    expect(['numbers' => [1,2,3,4], 'words' => ['hey', 'there']])
+        ->numbers->toEqual([1,2,3,4])->each->toBeInt->toBeLessThan(5)
+        ->words->each(fn ($word) => $word->toBeString())->not->toBeInt();
+});
+
+it('can compose complex expectations', function () {
+    expect(['foo' => 'bar', 'numbers' => [1,2,3,4]])
+        ->toContain('bar')->toBeArray()
+        ->numbers->toEqual([1,2,3,4])->not()->toEqual('bar')->each->toBeInt
+        ->foo->not->toEqual('world')->toEqual('bar')
+        ->numbers->toBeArray();
+});
+
+it('works with objects', function () {
+    expect((object) ['foo' => 'bar', 'numbers' => [1,2,3,4]])
+        ->foo->toEqual('bar')->not->toEqual('world')
+        ->numbers->each->toBeInt->tobeLessThan(5);
+});

--- a/tests/Expect/HigherOrder/methods.php
+++ b/tests/Expect/HigherOrder/methods.php
@@ -1,0 +1,100 @@
+<?php
+
+it('can access methods', function () {
+    expect(new HasMethods)
+        ->name()->toBeString()->toEqual('Has Methods');
+});
+
+it('can access multiple methods', function () {
+    expect(new HasMethods)
+        ->name()->toBeString()->toEqual('Has Methods')
+        ->quantity()->toBeInt()->toEqual(20);
+});
+
+it('works with not', function () {
+    expect(new HasMethods)
+        ->name()->not->toEqual('world')->toEqual('Has Methods')
+        ->quantity()->toEqual(20)->not()->toEqual('bar')->not->toBeNull;
+});
+
+it('can accept arguments', function () {
+    expect(new HasMethods)
+        ->multiply(5, 4)->toBeInt->toEqual(20);
+});
+
+it('works with each', function () {
+    expect(new HasMethods)
+        ->attributes()->toBeArray->each->not()->toBeNull
+        ->attributes()->each(function ($attribute) {
+            $attribute->not->toBeNull();
+        });
+});
+
+it('works inside of each', function () {
+    expect(new HasMethods)
+        ->books()->each(function ($book) {
+            $book->title->not->toBeNull->cost->toBeGreaterThan(19);
+        });
+});
+
+it('works with sequence', function () {
+    expect(new HasMethods)
+        ->books()->sequence(
+            function ($book) { $book->title->toEqual('Foo')->cost->toEqual(20); },
+            function ($book) { $book->title->toEqual('Bar')->cost->toEqual(30); },
+        );
+});
+
+it('can compose complex expectations', function () {
+    expect(new HasMethods)
+        ->toBeObject()
+        ->name()->toEqual('Has Methods')->not()->toEqual('bar')
+        ->quantity()->not->toEqual('world')->toEqual(20)->toBeInt
+        ->multiply(3, 4)->not->toBeString->toEqual(12)
+        ->attributes()->toBeArray()
+        ->books()->toBeArray->each->not->toBeEmpty
+        ->books()->sequence(
+            function ($book) { $book->title->toEqual('Foo')->cost->toEqual(20); },
+            function ($book) { $book->title->toEqual('Bar')->cost->toEqual(30); },
+        );
+});
+
+class HasMethods
+{
+    public function name()
+    {
+        return 'Has Methods';
+    }
+
+    public function quantity()
+    {
+        return 20;
+    }
+
+    public function multiply($x, $y)
+    {
+        return $x * $y;
+    }
+
+    public function attributes()
+    {
+        return [
+            'name' => $this->name(),
+            'quantity' => $this->quantity()
+        ];
+    }
+
+    public function books()
+    {
+        return [
+            [
+                'title' => 'Foo',
+                'cost' => 20,
+            ],
+            [
+                'title' => 'Bar',
+                'cost' => 30,
+            ],
+        ];
+    }
+}

--- a/tests/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Expect/HigherOrder/methodsAndProperties.php
@@ -1,0 +1,49 @@
+<?php
+
+it('can access methods and properties', function () {
+    expect(new HasMethodsAndProperties)
+        ->name->toEqual('Has Methods and Properties')->not()->toEqual('bar')
+        ->multiply(3, 4)->not->toBeString->toEqual(12)
+        ->posts->each(fn ($post) => $post->is_published->toBeTrue)
+        ->books()->toBeArray()
+        ->posts->toBeArray->each->not->toBeEmpty
+        ->books()->sequence(
+            function ($book) { $book->title->toEqual('Foo')->cost->toEqual(20); },
+            function ($book) { $book->title->toEqual('Bar')->cost->toEqual(30); },
+        );
+});
+
+class HasMethodsAndProperties
+{
+    public $name = 'Has Methods and Properties';
+
+    public $posts = [
+        [
+            'is_published' => true,
+            'title' => 'Foo'
+        ],
+        [
+            'is_published' => true,
+            'title' => 'Bar'
+        ]
+    ];
+
+    public function books()
+    {
+        return [
+            [
+                'title' => 'Foo',
+                'cost' => 20,
+            ],
+            [
+                'title' => 'Bar',
+                'cost' => 30,
+            ],
+        ];
+    }
+
+    public function multiply($x, $y)
+    {
+        return $x * $y;
+    }
+}

--- a/tests/Expect/HigherOrder/properties.php
+++ b/tests/Expect/HigherOrder/properties.php
@@ -48,7 +48,7 @@ it('can compose complex expectations', function () {
 });
 
 it('works with objects', function () {
-    expect((object) ['name' => 'foo', 'posts' => [['is_published' => true, 'title' => 'Foo'], ['is_published' => true, 'title' => 'Bar']]])
+    expect(new HasProperties)
         ->name->toEqual('foo')->not->toEqual('world')
         ->posts->toHaveCount(2)->each(function ($post) { $post->is_published->toBeTrue(); })
         ->posts->sequence(
@@ -56,3 +56,19 @@ it('works with objects', function () {
             function ($post) { $post->title->toEqual('Bar'); },
         );
 });
+
+class HasProperties
+{
+    public $name = 'foo';
+
+    public $posts = [
+        [
+            'is_published' => true,
+            'title' => 'Foo'
+        ],
+        [
+            'is_published' => true,
+            'title' => 'Bar'
+        ]
+    ];
+}

--- a/tests/Expect/HigherOrder/properties.php
+++ b/tests/Expect/HigherOrder/properties.php
@@ -12,6 +12,7 @@ it('can access multiple properties from the value', function () {
 
 it('works with not', function () {
     expect(['foo' => 'bar', 'hello' => 'world'])
+        ->foo->not->not->toEqual('bar')
         ->foo->not->toEqual('world')->toEqual('bar')
         ->hello->toEqual('world')->not()->toEqual('bar')->not->toBeNull;
 });


### PR DESCRIPTION
Hi!

Thanks for the amazing package 🚀 

This is a PR to allow properties to be dynamically accessed from the expectation value. For example, given a User, the following is possible:
```php
expect($user)
    ->name->toEqual('Dr Pest')
    ->email->not->toBeNull->toEqual('dr@pest.com')
    ->posts->toHaveCount(2)->each(fn ($post) => $post->published->toBeTrue)
    ->posts->sequence(
        fn ($post) => $post->title->toEqual('Simply the Pest'),
        fn ($post) => $post->title->toEqual('Pest Friends')
    )
```
> This will work with an `array` or an `object`.

I appreciate this PR is quite heavy on additions - eg. changing how the `__get` method functions in `Expectation` - and I may have missed something along the way. So, it might not even be desired. But I thought it was a cool feature to submit and see what everyone thinks. Happy to hear all thoughts and suggestions.

```php
expect($me)->is_waiting_patiently->toBeTrue
```

Thanks!

Update:

Support for methods has been added. So now the following would be possible:
```php
expect($user)->getName()->toEqual('Nuno')
```

And even:
```php
expect($calculator)->add(1, 4)->toEqual(5)
```