### PR TITLE
Add ray()

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -75,7 +75,7 @@ final class Expectation
     }
 
     /**
-     * Send the expectation value to Ray.
+     * Send the expectation value to Ray along with all given arguments.
      */
     public function ray(...$arguments): self
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -75,6 +75,20 @@ final class Expectation
     }
 
     /**
+     * Send the expectation value to Ray.
+     *
+     * @return self
+     */
+    public function ray(): self
+    {
+        if (function_exists('ray')) {
+            ray($this->value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Creates the opposite expectation for the value.
      */
     public function not(): OppositeExpectation

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -76,8 +76,6 @@ final class Expectation
 
     /**
      * Send the expectation value to Ray.
-     *
-     * @return self
      */
     public function ray(): self
     {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -77,10 +77,10 @@ final class Expectation
     /**
      * Send the expectation value to Ray.
      */
-    public function ray(): self
+    public function ray(...$arguments): self
     {
         if (function_exists('ray')) {
-            ray($this->value);
+            ray($this->value, ...$arguments);
         }
 
         return $this;

--- a/tests/Expect/ray.php
+++ b/tests/Expect/ray.php
@@ -1,0 +1,5 @@
+<?php
+
+it('will not blow up when ray is not installed', function () {
+    expect(true)->ray()->toBe(true);
+});


### PR DESCRIPTION
This PR adds a function `ray()` that makes it easy to display values under test in Ray.

A test was added to prove that it will not throw an exception when Ray is not installed and to prove that `ray()` is chainable.

I've not added `spatie/ray` as a dependency to keep the dev-requirements as light as they can be.

It could be questioned if a function for a paid product belongs in this package. I think it does because:
- the maintenance burden is minimal
- if we would use a Pest plugin, Pest users would not see `ray()` in the autocompletion of the IDE.