### PR TITLE
Add support to dot notation in toHaveKey expectation

### DIFF
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -523,7 +523,7 @@ final class Expectation
             $array = (array) $this->value;
         }
 
-        Assert::assertTrue(Arr::has($array, $key));
+        Assert::assertTrue(Arr::has($array, $key), "Failed asserting that an array has the key '$key'");
 
         if (func_num_args() > 1) {
             Assert::assertEquals($value, Arr::get($array, $key));

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -9,6 +9,7 @@ use Pest\Expectations\Concerns\Extendable;
 use Pest\Expectations\Helpers\Arr;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Exporter\Exporter;
 
 /**
@@ -523,7 +524,13 @@ final class Expectation
             $array = (array) $this->value;
         }
 
-        Assert::assertTrue(Arr::has($array, $key), "Failed asserting that an array has the key '$key'");
+        try {
+            Assert::assertTrue(Arr::has($array, $key));
+
+            /* @phpstan-ignore-next-line  */
+        } catch (ExpectationFailedException $exception) {
+            throw new ExpectationFailedException("Failed asserting that an array has the key '$key'", $exception->getComparisonFailure());
+        }
 
         if (func_num_args() > 1) {
             Assert::assertEquals($value, Arr::get($array, $key));

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -6,6 +6,7 @@ namespace Pest\Expectations;
 
 use BadMethodCallException;
 use Pest\Expectations\Concerns\Extendable;
+use Pest\Expectations\Helpers\Arr;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
 use SebastianBergmann\Exporter\Exporter;
@@ -522,10 +523,10 @@ final class Expectation
             $array = (array) $this->value;
         }
 
-        Assert::assertArrayHasKey($key, $array);
+        Assert::assertTrue(Arr::has($array, $key));
 
         if (func_num_args() > 1) {
-            Assert::assertEquals($value, $array[$key]);
+            Assert::assertEquals($value, Arr::get($array, $key));
         }
 
         return $this;

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Expectations\Helpers;
+
+/**
+ * Class Arr.
+ *
+ * Credits: most of this class methods and implementations
+ * belongs to the Arr helper of laravel/framework project
+ * (https://github.com/laravel/framework)
+ */
+final class Arr
+{
+    /**
+     * @param array<mixed> $array
+     * @param string|int   $key
+     */
+    public static function has(array $array, $key): bool
+    {
+        $key = (string) $key;
+
+        foreach (explode('.', $key) as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<mixed> $array
+     * @param string|int   $key
+     * @param null         $default
+     *
+     * @return array|mixed|null
+     */
+    public static function get(array $array, $key, $default = null)
+    {
+        $key = (string) $key;
+
+        if (array_key_exists($key, $array)) {
+            return $array[$key];
+        }
+
+        if (strpos($key, '.') === false) {
+            return $array[$key] ?? $default;
+        }
+
+        foreach (explode('.', $key) as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return $default;
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Expectations\Helpers;
+
+/**
+ * Class Arr.
+ *
+ * Credits: most of this class methods and implementations
+ * belongs to the Arr helper of laravel/framework project
+ * (https://github.com/laravel/framework)
+ */
+final class Arr
+{
+    /**
+     * @param array<mixed> $array
+     * @param string|int   $key
+     */
+    public static function has(array $array, $key): bool
+    {
+        $key = (string) $key;
+
+        if (array_key_exists($key, $array)) {
+            return true;
+        }
+
+        foreach (explode('.', $key) as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<mixed> $array
+     * @param string|int   $key
+     * @param null         $default
+     *
+     * @return array|mixed|null
+     */
+    public static function get(array $array, $key, $default = null)
+    {
+        $key = (string) $key;
+
+        if (array_key_exists($key, $array)) {
+            return $array[$key];
+        }
+
+        if (strpos($key, '.') === false) {
+            return $array[$key] ?? $default;
+        }
+
+        foreach (explode('.', $key) as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return $default;
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Pest\Expectations\Helpers;
 
 /**
- * Class Arr.
- *
  * Credits: most of this class methods and implementations
  * belongs to the Arr helper of laravel/framework project
- * (https://github.com/laravel/framework)
+ * (https://github.com/laravel/framework).
+ *
+ * @internal
  */
 final class Arr
 {

--- a/tests/Expect/toHaveKey.php
+++ b/tests/Expect/toHaveKey.php
@@ -2,14 +2,91 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
-test('pass', function () {
-    expect(['a' => 1, 'b', 'c' => 'world'])->toHaveKey('c');
-});
+dataset('test array', [
+    'test array' => [
+        'array' => [
+            'a'             => 1,
+            'b',
+            'c'             => 'world',
+            'd'             => [
+                'e' => 'hello',
+            ],
+            'key.with.dots' => false,
+        ],
+    ],
+]);
 
-test('failures', function () {
-    expect(['a' => 1, 'b', 'c' => 'world'])->toHaveKey('hello');
-})->throws(ExpectationFailedException::class);
+test('pass', function ($array, $key) {
+    expect($array)->toHaveKey($key);
+})->with('test array')->with([
+    'plain key'           => 'c',
+    'nested key'          => 'd.e',
+    'plain key with dots' => 'key.with.dots',
+]);
 
-test('not failures', function () {
-    expect(['a' => 1, 'hello' => 'world', 'c'])->not->toHaveKey('hello');
-})->throws(ExpectationFailedException::class);
+test('pass with value', function ($array, $key, $value) {
+    expect($array)->toHaveKey($key, $value);
+})->with('test array')->with([
+    'plain key'           => [
+        'key'   => 'c',
+        'value' => 'world',
+    ],
+    'nested key'          => [
+        'key'   => 'd.e',
+        'value' => 'hello',
+    ],
+    'plain key with dots' => [
+        'key'   => 'key.with.dots',
+        'value' => false,
+    ],
+]);
+
+test('failures', function ($array, $key) {
+    expect($array)->toHaveKey($key);
+})->with('test array')->with([
+    'plain key'           => 'foo',
+    'nested key'          => 'd.bar',
+    'plain key with dots' => 'missing.key.with.dots',
+])->throws(ExpectationFailedException::class);
+
+test('fails with wrong value', function ($array, $key, $value) {
+    expect($array)->toHaveKey($key, $value);
+})->with('test array')->with([
+    'plain key'           => [
+        'key'   => 'c',
+        'value' => 'bar',
+    ],
+    'nested key'          => [
+        'key'   => 'd.e',
+        'value' => 'foo',
+    ],
+    'plain key with dots' => [
+        'key'   => 'key.with.dots',
+        'value' => true,
+    ],
+])->throws(ExpectationFailedException::class);
+
+test('not failures', function ($array, $key) {
+    expect($array)->not->toHaveKey($key);
+})->with('test array')->with([
+    'plain key'           => 'c',
+    'nested key'          => 'd.e',
+    'plain key with dots' => 'key.with.dots',
+])->throws(ExpectationFailedException::class);
+
+test('not failures with correct value', function ($array, $key, $value) {
+    expect($array)->not->toHaveKey($key, $value);
+})->with('test array')->with([
+    'plain key'           => [
+        'key'   => 'c',
+        'value' => 'world',
+    ],
+    'nested key'          => [
+        'key'   => 'd.e',
+        'value' => 'hello',
+    ],
+    'plain key with dots' => [
+        'key'   => 'key.with.dots',
+        'value' => false,
+    ],
+])->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveKey.php
+++ b/tests/Expect/toHaveKey.php
@@ -2,91 +2,68 @@
 
 use PHPUnit\Framework\ExpectationFailedException;
 
-dataset('test array', [
-    'test array' => [
-        'array' => [
-            'a'             => 1,
-            'b',
-            'c'             => 'world',
-            'd'             => [
-                'e' => 'hello',
-            ],
-            'key.with.dots' => false,
-        ],
+$test_array = [
+    'a'             => 1,
+    'b',
+    'c'             => 'world',
+    'd'             => [
+        'e' => 'hello',
     ],
-]);
+    'key.with.dots' => false,
+];
 
-test('pass', function ($array, $key) {
-    expect($array)->toHaveKey($key);
-})->with('test array')->with([
-    'plain key'           => 'c',
-    'nested key'          => 'd.e',
-    'plain key with dots' => 'key.with.dots',
-]);
+test('pass')->expect($test_array)->toHaveKey('c');
+test('pass with nested key')->expect($test_array)->toHaveKey('d.e');
+test('pass with plain key with dots')->expect($test_array)->toHaveKey('key.with.dots');
 
-test('pass with value', function ($array, $key, $value) {
-    expect($array)->toHaveKey($key, $value);
-})->with('test array')->with([
-    'plain key'           => [
-        'key'   => 'c',
-        'value' => 'world',
-    ],
-    'nested key'          => [
-        'key'   => 'd.e',
-        'value' => 'hello',
-    ],
-    'plain key with dots' => [
-        'key'   => 'key.with.dots',
-        'value' => false,
-    ],
-]);
+test('pass with value check')->expect($test_array)->toHaveKey('c', 'world');
+test('pass with value check and nested key')->expect($test_array)->toHaveKey('d.e', 'hello');
+test('pass with value check and plain key with dots')->expect($test_array)->toHaveKey('key.with.dots', false);
 
-test('failures', function ($array, $key) {
-    expect($array)->toHaveKey($key);
-})->with('test array')->with([
-    'plain key'           => 'foo',
-    'nested key'          => 'd.bar',
-    'plain key with dots' => 'missing.key.with.dots',
-])->throws(ExpectationFailedException::class);
+test('failures', function () use ($test_array) {
+    expect($test_array)->toHaveKey('foo');
+})->throws(ExpectationFailedException::class, "Failed asserting that an array has the key 'foo'");
 
-test('fails with wrong value', function ($array, $key, $value) {
-    expect($array)->toHaveKey($key, $value);
-})->with('test array')->with([
-    'plain key'           => [
-        'key'   => 'c',
-        'value' => 'bar',
-    ],
-    'nested key'          => [
-        'key'   => 'd.e',
-        'value' => 'foo',
-    ],
-    'plain key with dots' => [
-        'key'   => 'key.with.dots',
-        'value' => true,
-    ],
-])->throws(ExpectationFailedException::class);
+test('failures with nested key', function () use ($test_array) {
+    expect($test_array)->toHaveKey('d.bar');
+})->throws(ExpectationFailedException::class, "Failed asserting that an array has the key 'd.bar'");
 
-test('not failures', function ($array, $key) {
-    expect($array)->not->toHaveKey($key);
-})->with('test array')->with([
-    'plain key'           => 'c',
-    'nested key'          => 'd.e',
-    'plain key with dots' => 'key.with.dots',
-])->throws(ExpectationFailedException::class);
+test('failures with plain key with dots', function () use ($test_array) {
+    expect($test_array)->toHaveKey('missing.key.with.dots');
+})->throws(ExpectationFailedException::class, "Failed asserting that an array has the key 'missing.key.with.dots'");
 
-test('not failures with correct value', function ($array, $key, $value) {
-    expect($array)->not->toHaveKey($key, $value);
-})->with('test array')->with([
-    'plain key'           => [
-        'key'   => 'c',
-        'value' => 'world',
-    ],
-    'nested key'          => [
-        'key'   => 'd.e',
-        'value' => 'hello',
-    ],
-    'plain key with dots' => [
-        'key'   => 'key.with.dots',
-        'value' => false,
-    ],
-])->throws(ExpectationFailedException::class);
+test('fails with wrong value', function () use ($test_array) {
+    expect($test_array)->toHaveKey('c', 'bar');
+})->throws(ExpectationFailedException::class);
+
+test('fails with wrong value and nested key', function () use ($test_array) {
+    expect($test_array)->toHaveKey('d.e', 'foo');
+})->throws(ExpectationFailedException::class);
+
+test('fails with wrong value and plain key with dots', function () use ($test_array) {
+    expect($test_array)->toHaveKey('key.with.dots', true);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () use ($test_array) {
+    expect($test_array)->not->toHaveKey('c');
+})->throws(ExpectationFailedException::class, "Expecting Array (...) not to have key 'c'");
+
+test('not failures with nested key', function () use ($test_array) {
+    expect($test_array)->not->toHaveKey('d.e');
+})->throws(ExpectationFailedException::class, "Expecting Array (...) not to have key 'd.e'");
+
+test('not failures with plain key with dots', function () use ($test_array) {
+    expect($test_array)->not->toHaveKey('key.with.dots');
+})->throws(ExpectationFailedException::class, "Expecting Array (...) not to have key 'key.with.dots'");
+
+test('not failures with correct value', function () use ($test_array) {
+    expect($test_array)->not->toHaveKey('c', 'world');
+})->throws(ExpectationFailedException::class);
+
+test('not failures with correct value and  with nested key', function () use ($test_array) {
+    expect($test_array)->not->toHaveKey('d.e', 'hello');
+})->throws(ExpectationFailedException::class);
+
+test('not failures with correct value and  with plain key with dots', function () use ($test_array) {
+    expect($test_array)->not->toHaveKey('key.with.dots', false);
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveKeys.php
+++ b/tests/Expect/toHaveKeys.php
@@ -3,13 +3,13 @@
 use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function () {
-    expect(['a' => 1, 'b', 'c' => 'world'])->toHaveKeys(['a', 'c']);
-});
+    expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'c', 'foo.bar']);
+})->only();
 
 test('failures', function () {
-    expect(['a' => 1, 'b', 'c' => 'world'])->toHaveKeys(['a', 'd']);
+    expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'd', 'foo.bar', 'hello.world']);
 })->throws(ExpectationFailedException::class);
 
 test('not failures', function () {
-    expect(['a' => 1, 'hello' => 'world', 'c'])->not->toHaveKeys(['hello', 'c']);
+    expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->not->toHaveKeys(['foo.bar', 'c', 'z']);
 })->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveKeys.php
+++ b/tests/Expect/toHaveKeys.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 test('pass', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'c', 'foo.bar']);
-})->only();
+});
 
 test('failures', function () {
     expect(['a' => 1, 'b', 'c' => 'world', 'foo' => ['bar' => 'baz']])->toHaveKeys(['a', 'd', 'foo.bar', 'hello.world']);


### PR DESCRIPTION
This PR wants to add support for dot notation when giving the array key to test with `expect()->toHaveKey()` expectation

this will allow to write a test like this one:

```php
it('has nested key', function () {
    $array = [
        'a' => 1,
        'b' => 2,
        'c' => [
            'd' => 3,
        ],
        'e.f' => 4,
    ];
    expect($array)->toHaveKey('c.d');
    expect($array)->toHaveKey('c.d', 3);
    expect($array)->toHaveKeys(['c.d', 'a']);
    expect($array)->toHaveKey('e.f');
});
```

As you can see in the last expectation of the example, In order to not be a breaking change, this implementation still allows to address an array key containing a dot in the string.

**some credits:** 

- to parse dot notated keys I added an helper `Arr` static class,  taking inspiration for `has()` and `get()` methods implementation from the [laravel/framework](https://github.com/laravel/framework) project

- @olivernybroe gave me the nice idea of allowing arrays with dots in it to obtain a non-breaking change

**bonus:** while adding these new tests cases to the `tests/Expect/toHaveKey.php` tests, I noticed that the second assertion of `toHaveKey($key, $value)` expectation (assert that the array has that specific value for the given key) was never tested, so added tests for it as well