### PR TITLE
Sequenced expectations can now be passed as non-callable values

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --no-interaction --no-progress --ansi
+      run: COMPOSER_ROOT_VERSION=dev-main composer update --no-interaction --no-progress --ansi
 
     - name: Run PHP-CS-Fixer
       run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run --ansi
@@ -45,7 +45,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --prefer-stable --no-interaction --no-progress --ansi
+      run: COMPOSER_ROOT_VERSION=dev-main composer update --prefer-stable --no-interaction --no-progress --ansi
 
     - name: Run PHPStan
       run: vendor/bin/phpstan analyse --no-progress --ansi

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: COMPOSER_ROOT_VERSION=dev-main composer update --no-interaction --no-progress --ansi
+      run: COMPOSER_ROOT_VERSION=dev-master composer update --no-interaction --no-progress --ansi
 
     - name: Run PHP-CS-Fixer
       run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run --ansi
@@ -45,7 +45,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: COMPOSER_ROOT_VERSION=dev-main composer update --prefer-stable --no-interaction --no-progress --ansi
+      run: COMPOSER_ROOT_VERSION=dev-master composer update --prefer-stable --no-interaction --no-progress --ansi
 
     - name: Run PHPStan
       run: vendor/bin/phpstan analyse --no-progress --ansi

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,6 +29,9 @@ jobs:
       run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run --ansi
 
   phpstan:
+    env:
+      COMPOSER_ROOT_VERSION: dev-master
+
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,6 +4,9 @@ on: ['push', 'pull_request']
 
 jobs:
   cs:
+    env:
+      COMPOSER_ROOT_VERSION: dev-master
+
     runs-on: ubuntu-latest
 
     name: Code Style
@@ -20,7 +23,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: COMPOSER_ROOT_VERSION=dev-master composer update --no-interaction --no-progress --ansi
+      run: composer update --no-interaction --no-progress --ansi
 
     - name: Run PHP-CS-Fixer
       run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run --ansi
@@ -45,7 +48,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: COMPOSER_ROOT_VERSION=dev-master composer update --prefer-stable --no-interaction --no-progress --ansi
+      run: composer update --prefer-stable --no-interaction --no-progress --ansi
 
     - name: Run PHPStan
       run: vendor/bin/phpstan analyse --no-progress --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      run: COMPOSER_ROOT_VERSION=dev-master composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
       run: ./vendor/bin/pest --colors=always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on: ['push', 'pull_request']
 
 jobs:
   ci:
+    env:
+      COMPOSER_ROOT_VERSION: dev-master
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -30,7 +32,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: COMPOSER_ROOT_VERSION=dev-master composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
       run: ./vendor/bin/pest --colors=always

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -110,7 +110,7 @@ final class Expectation
 
         if (is_callable($callback)) {
             foreach ($this->value as $item) {
-                $callback(expect($item));
+                $callback(new Expectation($item));
             }
         }
 
@@ -119,8 +119,10 @@ final class Expectation
 
     /**
      * Allows you to specify a sequential set of expectations for each item in a iterable "value".
+     *
+     * @param mixed ...$callbacks
      */
-    public function sequence(callable ...$callbacks): Expectation
+    public function sequence(...$callbacks): Expectation
     {
         if (!is_iterable($this->value)) {
             throw new BadMethodCallException('Expectation value is not iterable.');
@@ -138,7 +140,12 @@ final class Expectation
         }
 
         foreach ($values as $key => $item) {
-            call_user_func($callbacks[$key], expect($item), expect($keys[$key]));
+            if (is_callable($callbacks[$key])) {
+                call_user_func($callbacks[$key], new Expectation($item), new Expectation($keys[$key]));
+                continue;
+            }
+
+            (new Expectation($item))->toEqual($callbacks[$key]);
         }
 
         return $this;

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -101,11 +101,20 @@ final class Expectation
 
     /**
      * Creates an expectation on each item of the iterable "value".
+     *
+     * @param callable|mixed $callback
+     * @param mixed          $arguments
+     *
+     * @return Each|Expectation
      */
-    public function each(callable $callback = null): Each
+    public function each($callback = null, ...$arguments)
     {
         if (!is_iterable($this->value)) {
             throw new BadMethodCallException('Expectation value is not iterable.');
+        }
+
+        if (count($arguments) > 0) {
+            return $this->sequence($callback, ...$arguments);
         }
 
         if (is_callable($callback)) {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -101,20 +101,11 @@ final class Expectation
 
     /**
      * Creates an expectation on each item of the iterable "value".
-     *
-     * @param callable|mixed $callback
-     * @param mixed          $arguments
-     *
-     * @return Each|Expectation
      */
-    public function each($callback = null, ...$arguments)
+    public function each(callable $callback = null): Each
     {
         if (!is_iterable($this->value)) {
             throw new BadMethodCallException('Expectation value is not iterable.');
-        }
-
-        if (count($arguments) > 0) {
-            return $this->sequence($callback, ...$arguments);
         }
 
         if (is_callable($callback)) {

--- a/tests/Expect/each.php
+++ b/tests/Expect/each.php
@@ -87,17 +87,3 @@ it('accepts callables', function () {
 
     expect(static::getCount())->toBe(12);
 });
-
-test('it can be passed multiple arguments and defers to sequence if so', function () {
-    expect(['foo', 'bar', 'baz'])->sequence('foo', 'bar', 'baz');
-
-    expect(static::getCount())->toBe(3);
-
-    expect(['foo', 'bar', 'baz'])->each(
-        'foo',
-        function ($expectation) { $expectation->toEqual('bar')->toBeString(); },
-        'baz'
-    );
-
-    expect(static::getCount())->toBe(8); // +1 for first count check
-});

--- a/tests/Expect/each.php
+++ b/tests/Expect/each.php
@@ -87,3 +87,17 @@ it('accepts callables', function () {
 
     expect(static::getCount())->toBe(12);
 });
+
+test('it can be passed multiple arguments and defers to sequence if so', function () {
+    expect(['foo', 'bar', 'baz'])->sequence('foo', 'bar', 'baz');
+
+    expect(static::getCount())->toBe(3);
+
+    expect(['foo', 'bar', 'baz'])->each(
+        'foo',
+        function ($expectation) { $expectation->toEqual('bar')->toBeString(); },
+        'baz'
+    );
+
+    expect(static::getCount())->toBe(8); // +1 for first count check
+});

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -44,3 +44,9 @@ test('it works with associative arrays', function () {
             function ($expectation, $key) { $expectation->toEqual('boom'); $key->toEqual('baz'); },
         );
 });
+
+test('it can be passed non-callable values', function () {
+    expect(['foo', 'bar', 'baz'])->sequence('foo', 'bar', 'baz');
+
+    expect(static::getCount())->toBe(3);
+});

--- a/tests/Expect/sequence.php
+++ b/tests/Expect/sequence.php
@@ -50,3 +50,13 @@ test('it can be passed non-callable values', function () {
 
     expect(static::getCount())->toBe(3);
 });
+
+test('it can be passed a mixture of value types', function () {
+    expect(['foo', 'bar', 'baz'])->sequence(
+        'foo',
+        function ($expectation) { $expectation->toEqual('bar')->toBeString(); },
+        'baz'
+    );
+
+    expect(static::getCount())->toBe(4);
+});


### PR DESCRIPTION
Previously, values passed to the `sequence` method had to be callable closures.

This PR allows non-callable values to be passed to the `sequence` method. Each value will be wrapped in an expectation and `toEqual` will be called on it.

```php
expect(['foo', 'bar', 'baz'])->sequence('foo', 'bar', 'baz');
```

Up for discussion is whether or not `toBe` would be better than toEqual here?

This PR also fixes the CI pipeline, which previously would always fail when installing dependencies!