### PR TITLE
Higher Order Expectation nested calls

### DIFF
--- a/src/Concerns/Extendable.php
+++ b/src/Concerns/Extendable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Expectations\Concerns;
 
+use BadMethodCallException;
 use Closure;
-use Pest\Expectations\HigherOrderExpectation;
 
 /**
  * @internal
@@ -43,8 +43,7 @@ trait Extendable
     public function __call(string $method, array $parameters)
     {
         if (!static::hasExtend($method)) {
-            /* @phpstan-ignore-next-line */
-            return new HigherOrderExpectation($this, $this->value->$method(...$parameters));
+            throw new BadMethodCallException("$method is not a callable method name.");
         }
 
         /** @var Closure $extend */

--- a/src/Concerns/Extendable.php
+++ b/src/Concerns/Extendable.php
@@ -43,7 +43,8 @@ trait Extendable
     public function __call(string $method, array $parameters)
     {
         if (!static::hasExtend($method)) {
-            return new HigherOrderExpectation($this, $method, $parameters);
+            /* @phpstan-ignore-next-line */
+            return new HigherOrderExpectation($this, $this->value->$method(...$parameters));
         }
 
         /** @var Closure $extend */

--- a/src/Concerns/RetrievesValues.php
+++ b/src/Concerns/RetrievesValues.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Expectations\Concerns;
+
+/**
+ * @internal
+ */
+trait RetrievesValues
+{
+    /**
+     * Safely retrieve the value at the given key from an object or array.
+     *
+     * @param array<mixed>|object $value
+     * @param mixed               $default
+     *
+     * @return mixed
+     */
+    private function retrieve(string $key, $value, $default = null)
+    {
+        if (is_array($value)) {
+            return $value[$key] ?? $default;
+        }
+
+        // @phpstan-ignore-next-line
+        return $value->$key ?? $default;
+    }
+}

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -19,7 +19,9 @@ use SebastianBergmann\Exporter\Exporter;
  */
 final class Expectation
 {
-    use Extendable;
+    use Extendable {
+        __call as __extendsCall;
+    }
     use RetrievesValues;
 
     /**
@@ -696,6 +698,24 @@ final class Expectation
         }
 
         return $this->exporter->export($value);
+    }
+
+    /**
+     * Dynamically handle calls to the class or
+     * creates a new higher order expectation.
+     *
+     * @param array<int, mixed> $parameters
+     *
+     * @return mixed
+     */
+    public function __call(string $method, array $parameters)
+    {
+        if (!static::hasExtend($method)) {
+            /* @phpstan-ignore-next-line */
+            return new HigherOrderExpectation($this, $this->value->$method(...$parameters));
+        }
+
+        return $this->__extendsCall($method, $parameters);
     }
 
     /**

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -6,6 +6,7 @@ namespace Pest\Expectations;
 
 use BadMethodCallException;
 use Pest\Expectations\Concerns\Extendable;
+use Pest\Expectations\Concerns\RetrievesValues;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
 use SebastianBergmann\Exporter\Exporter;
@@ -19,6 +20,7 @@ use SebastianBergmann\Exporter\Exporter;
 final class Expectation
 {
     use Extendable;
+    use RetrievesValues;
 
     /**
      * The expectation value.
@@ -705,7 +707,7 @@ final class Expectation
     public function __get(string $name)
     {
         if (!method_exists($this, $name) && !static::hasExtend($name)) {
-            return new HigherOrderExpectation($this, $name);
+            return new HigherOrderExpectation($this, $this->retrieve($name, $this->value));
         }
 
         /* @phpstan-ignore-next-line */

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -6,6 +6,8 @@ namespace Pest\Expectations;
 
 use Pest\Expectations\Concerns\Expectations;
 use Pest\Expectations\Concerns\RetrievesValues;
+use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @internal
@@ -94,7 +96,12 @@ final class HigherOrderExpectation
      */
     private function expectationHasMethod(string $name): bool
     {
-        return method_exists($this->original, $name) || $this->original::hasExtend($name);
+        $methodNames = array_map(
+            function ($method): string { return strtolower($method->getName()); },
+            (new ReflectionClass($this->original))->getMethods(ReflectionMethod::IS_PUBLIC)
+        );
+
+        return in_array(strtolower($name), $methodNames, true) || $this->original::hasExtend($name);
     }
 
     /**

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -33,11 +33,6 @@ final class HigherOrderExpectation
     private $value;
 
     /**
-     * @var mixed
-     */
-    private $initialValue;
-
-    /**
      * @var bool
      */
     private $opposite = false;
@@ -51,16 +46,12 @@ final class HigherOrderExpectation
      * Creates a new higher order expectation.
      *
      * @param mixed $value
-     * @param mixed $initialValue
-     *
-     * @phpstan-ignore-next-line
      */
-    public function __construct(Expectation $original, $value, $initialValue = null)
+    public function __construct(Expectation $original, $value)
     {
         $this->original     = $original;
         $this->expectation  = $this->expect($value);
         $this->value        = $value;
-        $this->initialValue = $initialValue ?? $original->value;
     }
 
     /**
@@ -80,12 +71,11 @@ final class HigherOrderExpectation
      */
     public function __call(string $name, array $arguments): self
     {
-        if (!$this->originalHasMethod($name)) {
+        if (!$this->expectationHasMethod($name)) {
             return new self(
                 $this->original,
                 /* @phpstan-ignore-next-line */
-                ($this->lastCallWasAssertion ? $this->initialValue : $this->value)->$name(...$arguments),
-                $this->initialValue
+                ($this->lastCallWasAssertion ? $this->original->value : $this->value)->$name(...$arguments),
             );
         }
 
@@ -101,11 +91,10 @@ final class HigherOrderExpectation
             return $this->not();
         }
 
-        if (!$this->originalHasMethod($name)) {
+        if (!$this->expectationHasMethod($name)) {
             return new self(
                 $this->original,
-                $this->retrieve($name, $this->lastCallWasAssertion ? $this->initialValue : $this->value),
-                $this->initialValue
+                $this->retrieve($name, $this->lastCallWasAssertion ? $this->original->value : $this->value),
             );
         }
 
@@ -115,7 +104,7 @@ final class HigherOrderExpectation
     /**
      * Determines if the original expectation has the given method name.
      */
-    private function originalHasMethod(string $name): bool
+    private function expectationHasMethod(string $name): bool
     {
         return method_exists($this->original, $name) || $this->original::hasExtend($name);
     }

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -28,11 +28,6 @@ final class HigherOrderExpectation
     private $expectation;
 
     /**
-     * @var mixed
-     */
-    private $value;
-
-    /**
      * @var bool
      */
     private $opposite = false;
@@ -51,7 +46,6 @@ final class HigherOrderExpectation
     {
         $this->original     = $original;
         $this->expectation  = $this->expect($value);
-        $this->value        = $value;
     }
 
     /**
@@ -110,7 +104,7 @@ final class HigherOrderExpectation
      */
     private function getValue()
     {
-        return $this->shouldReset ? $this->original->value : $this->value;
+        return $this->shouldReset ? $this->original->value : $this->expectation->value;
     }
 
     /**

--- a/src/HigherOrderExpectation.php
+++ b/src/HigherOrderExpectation.php
@@ -116,14 +116,11 @@ final class HigherOrderExpectation
      */
     private function performAssertion(string $name, array $arguments): self
     {
-        $expectation = $this->opposite
-            ? $this->expectation->not()
-            : $this->expectation;
+        /* @phpstan-ignore-next-line */
+        $this->expectation = ($this->opposite ? $this->expectation->not() : $this->expectation)->{$name}(...$arguments);
 
-        $this->expectation = $expectation->{$name}(...$arguments); // @phpstan-ignore-line
-
-        $this->lastCallWasAssertion = true;
         $this->opposite             = false;
+        $this->lastCallWasAssertion = true;
 
         return $this;
     }

--- a/tests/Expect/HigherOrder/methods.php
+++ b/tests/Expect/HigherOrder/methods.php
@@ -59,6 +59,13 @@ it('can compose complex expectations', function () {
         );
 });
 
+it('can handle nested method calls', function () {
+    expect(new HasMethods())
+        ->newInstance()->newInstance()->name()->toEqual('Has Methods')
+        ->newInstance()->name()->toEqual('Has Methods')
+        ->name()->toEqual('Has Methods');
+});
+
 class HasMethods
 {
     public function name()
@@ -96,5 +103,15 @@ class HasMethods
                 'cost'  => 30,
             ],
         ];
+    }
+
+    public function deeper()
+    {
+        return new HasMoreMethods();
+    }
+
+    public function newInstance()
+    {
+        return new static();
     }
 }

--- a/tests/Expect/HigherOrder/methods.php
+++ b/tests/Expect/HigherOrder/methods.php
@@ -61,8 +61,8 @@ it('can compose complex expectations', function () {
 
 it('can handle nested method calls', function () {
     expect(new HasMethods())
-        ->newInstance()->newInstance()->name()->toEqual('Has Methods')
-        ->newInstance()->name()->toEqual('Has Methods')
+        ->newInstance()->newInstance()->name()->toEqual('Has Methods')->toBeString()
+        ->newInstance()->name()->toEqual('Has Methods')->not->toBeInt
         ->name()->toEqual('Has Methods');
 });
 

--- a/tests/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Expect/HigherOrder/methodsAndProperties.php
@@ -16,9 +16,9 @@ it('can access methods and properties', function () {
 
 it('can handle nested methods and properties', function () {
     expect(new HasMethodsAndProperties())
-        ->meta->foo->bar->toBeString()->toEqual('baz')
+        ->meta->foo->bar->toBeString()->toEqual('baz')->not->toBeInt
         ->newInstance()->meta->foo->toBeArray()
-        ->newInstance()->multiply(2, 2)->toEqual(4)
+        ->newInstance()->multiply(2, 2)->toEqual(4)->not->toEqual(5)
         ->newInstance()->books()->toBeArray();
 });
 

--- a/tests/Expect/HigherOrder/methodsAndProperties.php
+++ b/tests/Expect/HigherOrder/methodsAndProperties.php
@@ -14,9 +14,19 @@ it('can access methods and properties', function () {
         );
 });
 
+it('can handle nested methods and properties', function () {
+    expect(new HasMethodsAndProperties())
+        ->meta->foo->bar->toBeString()->toEqual('baz')
+        ->newInstance()->meta->foo->toBeArray()
+        ->newInstance()->multiply(2, 2)->toEqual(4)
+        ->newInstance()->books()->toBeArray();
+});
+
 class HasMethodsAndProperties
 {
     public $name = 'Has Methods and Properties';
+
+    public $meta = ['foo' => ['bar' => 'baz']];
 
     public $posts = [
         [
@@ -46,5 +56,10 @@ class HasMethodsAndProperties
     public function multiply($x, $y)
     {
         return $x * $y;
+    }
+
+    public function newInstance()
+    {
+        return new static();
     }
 }

--- a/tests/Expect/HigherOrder/properties.php
+++ b/tests/Expect/HigherOrder/properties.php
@@ -58,6 +58,12 @@ it('works with objects', function () {
         );
 });
 
+it('works with nested properties', function () {
+    expect(new HasProperties())
+        ->nested->foo->bar->toBeString()->toEqual('baz')
+        ->posts->toBeArray()->toHaveCount(2);
+});
+
 class HasProperties
 {
     public $name = 'foo';
@@ -71,5 +77,9 @@ class HasProperties
             'is_published' => true,
             'title'        => 'Bar',
         ],
+    ];
+
+    public $nested = [
+        'foo' => ['bar' => 'baz'],
     ];
 }


### PR DESCRIPTION
Okay, here it is!

Previously, Higher Order Expectations were "one level deep", so to speak. That is to say that you could only call properties and methods *directly* on the expectation value.

```php
$value = ['foo' => ['bar' => 'baz']];

expect($value)->foo->toBeArray; // This would work, but...
expect($value)->foo->bar->toEqual('baz'); // This would fail previously
```

In this PR, I've refactored Higher Order Expectations to support nested calls of theoretically infinite depth.

```php
it('can handle deeply nested things', function () {
   expect(new HasMethodsAndProperties())
        ->meta->foo->bar->toBeString()->toEqual('baz')->not->toBeInt
        ->someMethod()->meta->foo->toBeArray()
        ->anotherMethod()->multiply(2, 2)->toEqual(4)->not->toEqual(5)
        ->library()->books()->toBeArray();
});
```

After performing assertions, the expectation will "reset" back to the top level.

The same restriction applies as before, that if you call a method that exists on the `Expectation` class, *that* will be called instead of the property or method on the expectation value.

Let me know what you think!